### PR TITLE
fix: make navigation links visible on mobile

### DIFF
--- a/src/gatsby-theme-developer/styles/_header.scss
+++ b/src/gatsby-theme-developer/styles/_header.scss
@@ -44,8 +44,19 @@ header {
   }
 
   .navbar-nav {
-    flex-direction: row;
-    margin-top: 0;
+    flex-direction: column;
+    margin-top: 1rem;
+    padding-top: 1rem;
+    border-top: 1px solid $gray-200;
+    width: 100%;
+
+    @media (min-width: 768px) {
+      flex-direction: row;
+      margin-top: 0;
+      padding-top: 0;
+      border-top: none;
+      width: auto;
+    }
 
     .nav-item {
       margin-left: 0;
@@ -53,12 +64,16 @@ header {
 
     .nav-link {
       padding: 0.25rem 0;
-      margin: 0 0 0 1.5rem;
+      margin: 0.5rem 0;
       font-size: 0.875rem;
       font-weight: 500;
       text-transform: uppercase;
       letter-spacing: 0.05em;
       border-bottom: 2px solid transparent;
+
+      @media (min-width: 768px) {
+        margin: 0 0 0 1.5rem;
+      }
 
       &:first-child {
         margin-left: 0;
@@ -80,18 +95,3 @@ header {
   }
 }
 
-// Mobile adjustments
-@media (max-width: 767px) {
-  header {
-    .navbar-nav {
-      margin-top: 1rem;
-      padding-top: 1rem;
-      border-top: 1px solid $gray-200;
-      width: 100%;
-
-      .nav-link {
-        margin: 0 1rem 0 0;
-      }
-    }
-  }
-}


### PR DESCRIPTION
- Changed navigation to use mobile-first approach with flex-direction: column
- Navigation now displays vertically stacked links on mobile devices
- Desktop view (768px+) maintains horizontal row layout
- Removed redundant mobile media query section